### PR TITLE
Old style exception --> new style for Python 2 & 3

### DIFF
--- a/Lib/Tools.py
+++ b/Lib/Tools.py
@@ -34,7 +34,7 @@ class Tools :
 			header = response.headers
 			body = response.read()
 			code = response.code
-		except urllib2.HTTPError, e:
+		except urllib2.HTTPError as e:
 			header = e.headers
 			body = e.read()
 			code = e.code


### PR DESCRIPTION
Old style exceptions are a syntax error in Python 3 while new style exceptions work in both Python 2 and Python 3.